### PR TITLE
feat: Add flake-module to run nix-health in devShell shellHook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         inputs.treefmt-nix.flakeModule
         inputs.rust-flake.flakeModules.default
         inputs.rust-flake.flakeModules.nixpkgs
+        ./module/flake-module.nix
       ];
       perSystem = { config, self', pkgs, lib, system, ... }: {
         rust-project.crane.args = {
@@ -52,20 +53,19 @@
           inputsFrom = [
             self'.devShells.nix_health
             config.treefmt.build.devShell
+            config.nix-health.outputs.devShell
           ];
-          shellHook = ''
-            trap "${lib.getExe pkgs.toilet} NIX SHELL FAILED --filter gay -f smmono9" ERR
-
-            ${lib.getExe pkgs.nix-health} --quiet .
-          '';
         };
         packages.default = self'.packages.nix_health.overrideAttrs ({
           meta.mainProgram = "nix-health";
         });
       };
 
-      flake.nix-health.default = {
-        nix-version.min-required = "2.17.0";
+      flake = {
+        flakeModule = ./module/flake-module.nix;
+        nix-health.default = {
+          nix-version.min-required = "2.17.0";
+        };
       };
     };
 }

--- a/module/flake-module.nix
+++ b/module/flake-module.nix
@@ -1,0 +1,30 @@
+{ self, lib, flake-parts-lib, ... }:
+
+let
+  inherit (flake-parts-lib)
+    mkPerSystemOption;
+in
+{
+  options = {
+    perSystem = mkPerSystemOption
+      ({ config, pkgs, ... }: {
+        options.nix-health.outputs.devShell = lib.mkOption {
+          type = lib.types.package;
+          description = ''
+            Add a shellHook for running nix-health on the flake.
+          '';
+          default = pkgs.mkShell {
+            shellHook = ''
+              # Must use a subshell so that 'trap' handles only nix-health
+              # crashes.
+              (
+                trap "${lib.getExe pkgs.toilet} NIX UNHEALTHY --filter gay -f smmono9" ERR
+
+                ${lib.getExe pkgs.nix-health} --quiet .
+              )
+            '';
+          };
+        };
+      });
+  };
+}

--- a/module/flake.nix
+++ b/module/flake.nix
@@ -1,0 +1,5 @@
+{
+  outputs = _: {
+    flakeModule = ./flake-module.nix;
+  };
+}


### PR DESCRIPTION
Resolves #14. And #7 can be done on top of this (in separate PR).

<img width="501" alt="image" src="https://github.com/juspay/nix-health/assets/3998/9f3b3141-611f-484f-b897-3e375c02dff5">
